### PR TITLE
Improve own classes detection

### DIFF
--- a/lib/degem/find_unused.rb
+++ b/lib/degem/find_unused.rb
@@ -20,8 +20,7 @@ module Degem
     attr_reader :gemfile_path
 
     def reject_railties(rubygems)
-      rubygems.reject(&:rails?)
-        .reject { _1.consts.grep(/Rails::Railtie|Rails::Engine/).any? }
+      rubygems.reject(&:rails?).reject(&:railtie?)
     end
 
     def reject_used(rubygems)

--- a/lib/degem/find_unused.rb
+++ b/lib/degem/find_unused.rb
@@ -11,7 +11,7 @@ module Degem
 
     def call
       rubygems = gemfile.rubygems.reject { _1.name == "degem" }
-      rubygems = reject_railties(rubygems) if rails?
+      rubygems = reject_railties(rubygems) if gemfile.rails?
       reject_used(rubygems)
     end
 
@@ -52,10 +52,6 @@ module Degem
 
     def gemfile
       @gemfile ||= ParseGemfile.new(@gem_specification).call(gemfile_path)
-    end
-
-    def rails?
-      @rails ||= gemfile.rails?
     end
   end
 end

--- a/lib/degem/find_unused.rb
+++ b/lib/degem/find_unused.rb
@@ -20,8 +20,7 @@ module Degem
     attr_reader :gemfile_path
 
     def reject_railties(rubygems)
-      rubygems
-        .reject { _1.name == "rails" }
+      rubygems.reject(&:rails?)
         .reject { _1.consts.grep(/Rails::Railtie|Rails::Engine/).any? }
     end
 

--- a/lib/degem/gemfile.rb
+++ b/lib/degem/gemfile.rb
@@ -15,7 +15,7 @@ module Degem
     end
 
     def rails?
-      @rails ||= rubygems.map(&:name).include?("rails")
+      !!rubygems.find(&:rails?)
     end
 
     private

--- a/lib/degem/parse_ruby.rb
+++ b/lib/degem/parse_ruby.rb
@@ -31,7 +31,7 @@ module Degem
     end
 
     def requires = @requires.to_a
-    def consts = paths + classes + modules
+    def consts = (@paths.union(@classes).union(@modules)).to_a
     def paths = @paths.to_a
     def classes = @classes.to_a
     def modules = @modules.to_a
@@ -52,8 +52,10 @@ module Degem
     def visit_class_node(node)
       @stack.push(node)
       super
-      @classes.add(@stack.map(&:name).join("::"))
       @stack.pop
+      *modules, klass = node.constant_path.full_name_parts rescue [[], node.name]
+      @modules.add((@stack.map(&:name) + modules).join("::")) if modules.any?
+      @classes.add((@stack.map(&:name) + modules + [klass]).join("::"))
     end
 
     def visit_constant_path_node(node)

--- a/lib/degem/parse_ruby.rb
+++ b/lib/degem/parse_ruby.rb
@@ -52,7 +52,7 @@ module Degem
     end
 
     def visit_constant_path_node(node)
-      consts_from(node).each { @consts.add(_1) }
+      paths_from(node).each { @consts.add(_1) }
       super
     end
 
@@ -83,7 +83,7 @@ module Degem
       acc
     end
 
-    def consts_from(node)
+    def paths_from(node)
       from_ancestor_to(node)
         .filter_map { _1.respond_to?(:name) ? _1.name.to_s : nil }
         .tap { _1.singleton_class.include(Scan) }

--- a/lib/degem/parse_ruby.rb
+++ b/lib/degem/parse_ruby.rb
@@ -22,14 +22,19 @@ module Degem
   class Visitor < Prism::Visitor
     def initialize
       @requires = Set.new
-      @consts = Set.new
+      @paths = Set.new
+      @classes = Set.new
+      @modules = Set.new
       @path = nil
       @stack = []
       super
     end
 
     def requires = @requires.to_a
-    def consts = @consts.to_a
+    def consts = paths + classes + modules
+    def paths = @paths.to_a
+    def classes = @classes.to_a
+    def modules = @modules.to_a
     attr_writer :path
 
     def visit_call_node(node)
@@ -40,24 +45,24 @@ module Degem
     def visit_module_node(node)
       @stack.push(node)
       super
-      @consts.add(@stack.map(&:name).join("::"))
+      @modules.add(@stack.map(&:name).join("::"))
       @stack.pop
     end
 
     def visit_class_node(node)
       @stack.push(node)
       super
-      @consts.add(@stack.map(&:name).join("::"))
+      @classes.add(@stack.map(&:name).join("::"))
       @stack.pop
     end
 
     def visit_constant_path_node(node)
-      paths_from(node).each { @consts.add(_1) }
+      paths_from(node).each { @paths.add(_1) }
       super
     end
 
     def visit_constant_read_node(node)
-      @consts.add(node.name.to_s) unless @stack.find { _1.constant_path == node }
+      @paths.add(node.name.to_s) unless @stack.find { _1.constant_path == node }
       super
     end
 

--- a/lib/degem/rubygem.rb
+++ b/lib/degem/rubygem.rb
@@ -13,6 +13,10 @@ module Degem
       name == "rails"
     end
 
+    def railtie?
+      parsed.consts.grep(/Rails::Railtie|Rails::Engine/).any?
+    end
+
     def consts
       parsed.consts
     end

--- a/lib/degem/rubygem.rb
+++ b/lib/degem/rubygem.rb
@@ -29,7 +29,9 @@ module Degem
         *name.split("-").each_cons(2).to_a.map(&:join)
       ]
 
-      parsed.consts.filter { |const| variations.any? { |variation| const.downcase.start_with?(variation.downcase) } }
+      parsed.classes + (parsed.modules + parsed.paths).filter do |const|
+        variations.any? { |variation| const.downcase == variation.downcase }
+      end
     end
 
     private

--- a/lib/degem/rubygem.rb
+++ b/lib/degem/rubygem.rb
@@ -17,10 +17,6 @@ module Degem
       parsed.consts.grep(/Rails::Railtie|Rails::Engine/).any?
     end
 
-    def consts
-      parsed.consts
-    end
-
     def own_consts
       variations = [
         name,
@@ -33,7 +29,7 @@ module Degem
         *name.split("-").each_cons(2).to_a.map(&:join)
       ]
 
-      consts.filter { |const| variations.any? { |variation| const.downcase == variation.downcase } }
+      parsed.consts.filter { |const| variations.any? { |variation| const.downcase == variation.downcase } }
     end
 
     private

--- a/lib/degem/rubygem.rb
+++ b/lib/degem/rubygem.rb
@@ -42,7 +42,7 @@ module Degem
       @parsed ||=
         begin
           gem_path = @gem_specification.find_by_name(name).full_gem_path
-          paths = Dir.glob(File.join(gem_path, "**/*.rb"))
+          paths = Dir.glob(File.join(gem_path, "**", "lib", "**/*.rb"))
           ParseRuby.new.call(paths)
         end
     end

--- a/lib/degem/rubygem.rb
+++ b/lib/degem/rubygem.rb
@@ -9,6 +9,10 @@ module Degem
       super(rubygem)
     end
 
+    def rails?
+      name == "rails"
+    end
+
     def consts
       parsed.consts
     end

--- a/lib/degem/rubygem.rb
+++ b/lib/degem/rubygem.rb
@@ -29,7 +29,7 @@ module Degem
         *name.split("-").each_cons(2).to_a.map(&:join)
       ]
 
-      parsed.consts.filter { |const| variations.any? { |variation| const.downcase == variation.downcase } }
+      parsed.consts.filter { |const| variations.any? { |variation| const.downcase.start_with?(variation.downcase) } }
     end
 
     private

--- a/test/test_find_unused.rb
+++ b/test/test_find_unused.rb
@@ -120,7 +120,7 @@ class TestFindUnused < Minitest::Test
       bundle_install(%w[rails]) do |gemspec_paths|
         gem_specification = TestableGemSpecification.new(gemspec_paths)
         actual = Degem::FindUnused.new(gemfile_path:, gem_specification:, bundle_paths: ->(_) { [] }).call
-        assert_empty actual.map(&:name)
+        assert_empty actual
       end
     end
   end
@@ -138,7 +138,7 @@ class TestFindUnused < Minitest::Test
         bundle_install(["rails", { "foo" => railtie }]) do |gemspec_paths|
           gem_specification = TestableGemSpecification.new(gemspec_paths)
           actual = Degem::FindUnused.new(gemfile_path:, gem_specification:, bundle_paths: ->(_) { [] }).call
-          assert_empty actual.map(&:name)
+          assert_empty actual
         end
       end
     end

--- a/test/test_find_unused.rb
+++ b/test/test_find_unused.rb
@@ -49,6 +49,18 @@ class TestFindUnused < Minitest::Test
     end
   end
 
+  def test_it_detects_unused_gems_based_on_the_class
+    with_gemfile do |gemfile_path|
+      bundle_install(["countries" => "module ISO3166; class Country; end; end"]) do |gemspec_paths|
+        with_file(path: File.join("app", "services", "foo.rb"), content: "ISO3166::Country.bar") do |f|
+          gem_specification = TestableGemSpecification.new(gemspec_paths)
+          actual = Degem::FindUnused.new(gemfile_path:, gem_specification:, bundle_paths: ->(_) { [f] }).call
+          assert_empty actual
+        end
+      end
+    end
+  end
+
   def test_it_detects_unused_gems_based_on_the_top_call
     with_gemfile do |gemfile_path|
       bundle_install(["foo" => "class Foo; def call; end; end"]) do |gemspec_paths|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,8 +35,8 @@ def with_gemfile(&)
   with_file(path: File.join("app", "Gemfile"), content: content, &)
 end
 
-def bundle_install(rubygems, gemspec_paths = [], &block)
-  return yield(gemspec_paths) if rubygems == []
+def bundle_install(rubygems, gem_paths = [], gemspec_paths = [], &block)
+  return yield(gemspec_paths, gem_paths) if rubygems == []
 
   gem_name, source_code =
     if rubygems[0].instance_of?(Hash)
@@ -45,21 +45,21 @@ def bundle_install(rubygems, gemspec_paths = [], &block)
       [rubygems[0], ""]
     end
 
-  with_gem(name: gem_name, source_code: source_code) do |_gem_path, gemspec_path|
+  with_gem(name: gem_name, source_code: source_code) do |gem_path, gemspec_path|
     File.write(File.join(TEST_DIR, "app", "Gemfile"), "\ngem '#{gem_name}'", mode: "a")
-    bundle_install(rubygems[1..], gemspec_paths + [gemspec_path], &block)
+    bundle_install(rubygems[1..], gem_paths + [gem_path], gemspec_paths + [gemspec_path], &block)
   end
 end
 
 def with_gem(name:, source_code: "")
   gemspec = <<~CONTENT
-      Gem::Specification.new do |spec|
-        spec.name    = "#{name}"
-        spec.version = "1.0.0"
-        spec.summary = "Gemspec summary"
-        spec.files   = Dir.glob("lib/**/*") + Dir.glob("exe/*")
-        spec.authors = ["Riccardo Odone"]
-      end
+    Gem::Specification.new do |spec|
+      spec.name    = "#{name}"
+      spec.version = "1.0.0"
+      spec.summary = "Gemspec summary"
+      spec.files   = Dir.glob("lib/**/*") + Dir.glob("exe/*")
+      spec.authors = ["Riccardo Odone"]
+    end
   CONTENT
 
   with_gemspec(gem_name: name, content: gemspec) do |gemspec_path|

--- a/test/test_parse_ruby.rb
+++ b/test/test_parse_ruby.rb
@@ -266,4 +266,36 @@ class TestParseRuby < Minitest::Test
       assert_array %w[Module], actual.modules
     end
   end
+
+  def test_it_parses_module_colon_colon_class
+    content = <<~CONTENT
+      class PG::Result
+      end
+    CONTENT
+
+    with_file(content: content) do |path|
+      actual = Degem::ParseRuby.new.call(path)
+      assert_empty actual.requires
+      assert_array %w[PG PG::Result], actual.consts
+      assert_array %w[PG::Result], actual.classes
+      assert_array %w[PG], actual.modules
+    end
+  end
+
+  def test_it_parses_module_module_colon_colon_class
+    content = <<~CONTENT
+      module Module1
+        class Module2::Klass
+        end
+      end
+    CONTENT
+
+    with_file(content: content) do |path|
+      actual = Degem::ParseRuby.new.call(path)
+      assert_empty actual.requires
+      assert_array %w[Module1 Module1::Module2 Module1::Module2::Klass Module2 Module2::Klass], actual.consts
+      assert_array %w[Module1::Module2::Klass], actual.classes
+      assert_array %w[Module1 Module1::Module2], actual.modules
+    end
+  end
 end

--- a/test/test_parse_ruby.rb
+++ b/test/test_parse_ruby.rb
@@ -24,6 +24,9 @@ class TestParseRuby < Minitest::Test
     with_file(content: content) do |path|
       actual = Degem::ParseRuby.new.call(path)
       assert_array %w[foo bar baz], actual.requires
+      assert_array %w[Bundler File], actual.consts
+      assert_empty actual.classes
+      assert_empty actual.modules
     end
   end
 
@@ -37,7 +40,10 @@ class TestParseRuby < Minitest::Test
 
     with_file(content: content) do |path|
       actual = Degem::ParseRuby.new.call(path)
+      assert_empty actual.requires
       assert_array %w[Klass Klass::KK], actual.consts
+      assert_array %w[Klass Klass::KK], actual.classes
+      assert_empty actual.modules
     end
   end
 
@@ -51,7 +57,10 @@ class TestParseRuby < Minitest::Test
 
     with_file(content: content) do |path|
       actual = Degem::ParseRuby.new.call(path)
+      assert_empty actual.requires
       assert_array %w[M M::K], actual.consts
+      assert_array %w[M::K], actual.classes
+      assert_array %w[M], actual.modules
     end
   end
 
@@ -70,7 +79,10 @@ class TestParseRuby < Minitest::Test
 
     with_file(content: content) do |path|
       actual = Degem::ParseRuby.new.call(path)
+      assert_empty actual.requires
       assert_array %w[M1 M1::K1 M1::M2 M1::M2::K2], actual.consts
+      assert_array %w[M1::K1 M1::M2::K2], actual.classes
+      assert_array %w[M1 M1::M2], actual.modules
     end
   end
 
@@ -81,7 +93,10 @@ class TestParseRuby < Minitest::Test
     with_file(content: content1) do |path1|
       with_file(content: content2) do |path2|
         actual = Degem::ParseRuby.new.call([path1, path2])
+        assert_empty actual.requires
         assert_array %w[Klass M], actual.consts
+        assert_array %w[Klass], actual.classes
+        assert_array %w[M], actual.modules
       end
     end
   end
@@ -91,6 +106,8 @@ class TestParseRuby < Minitest::Test
       actual = Degem::ParseRuby.new.call(path)
       assert_empty actual.requires
       assert_empty actual.consts
+      assert_empty actual.classes
+      assert_empty actual.modules
     end
   end
 
@@ -102,7 +119,10 @@ class TestParseRuby < Minitest::Test
 
     with_file(content: content) do |path|
       actual = Degem::ParseRuby.new.call(path)
+      assert_empty actual.requires
       assert_array %w[Klass SuperKlass], actual.consts
+      assert_array %w[Klass], actual.classes
+      assert_empty actual.modules
     end
   end
 
@@ -114,7 +134,10 @@ class TestParseRuby < Minitest::Test
 
     with_file(content: content) do |path|
       actual = Degem::ParseRuby.new.call(path)
+      assert_empty actual.requires
       assert_array %w[Klass Module::SuperKlass Module], actual.consts
+      assert_array %w[Klass], actual.classes
+      assert_empty actual.modules
     end
   end
 
@@ -126,7 +149,10 @@ class TestParseRuby < Minitest::Test
 
     with_file(content: content) do |path|
       actual = Degem::ParseRuby.new.call(path)
+      assert_empty actual.requires
       assert_array %w[Klass Module::Nested::SuperKlass Module::Nested Module], actual.consts
+      assert_array %w[Klass], actual.classes
+      assert_empty actual.modules
     end
   end
 
@@ -138,6 +164,9 @@ class TestParseRuby < Minitest::Test
     with_file(content: content) do |path|
       actual = Degem::ParseRuby.new.call(path)
       assert_empty actual.requires
+      assert_empty actual.consts
+      assert_empty actual.classes
+      assert_empty actual.modules
     end
   end
 
@@ -148,7 +177,10 @@ class TestParseRuby < Minitest::Test
 
     with_file(content: content) do |path|
       actual = Degem::ParseRuby.new.call(path)
+      assert_empty actual.requires
       assert_array %w[Module1 Module1::Module2 Module1::Module2::Module3], actual.consts
+      assert_empty actual.classes
+      assert_empty actual.modules
     end
   end
 
@@ -161,7 +193,10 @@ class TestParseRuby < Minitest::Test
 
     with_file(content: content) do |path|
       actual = Degem::ParseRuby.new.call(path)
+      assert_empty actual.requires
       assert_array %w[Klass Module1 Module1::Module2 Module1::Module2::Module3], actual.consts
+      assert_array %w[Klass], actual.classes
+      assert_empty actual.modules
     end
   end
 
@@ -175,7 +210,10 @@ class TestParseRuby < Minitest::Test
 
     with_file(content: content) do |path|
       actual = Degem::ParseRuby.new.call(path)
+      assert_empty actual.requires
       assert_array %w[Foo], actual.consts
+      assert_array %w[Foo], actual.classes
+      assert_empty actual.modules
     end
   end
 
@@ -186,7 +224,10 @@ class TestParseRuby < Minitest::Test
 
     with_file(content: content) do |path|
       actual = Degem::ParseRuby.new.call(path)
+      assert_empty actual.requires
       assert_array %w[Foo], actual.consts
+      assert_empty actual.classes
+      assert_empty actual.modules
     end
   end
 
@@ -201,7 +242,10 @@ class TestParseRuby < Minitest::Test
 
     with_file(content: content) do |path|
       actual = Degem::ParseRuby.new.call(path)
+      assert_empty actual.requires
       assert_array %w[Module Module::Klass Rack Rack::Utm], actual.consts
+      assert_array %w[Module::Klass], actual.classes
+      assert_array %w[Module], actual.modules
     end
   end
 
@@ -216,7 +260,10 @@ class TestParseRuby < Minitest::Test
 
     with_file(content: content) do |path|
       actual = Degem::ParseRuby.new.call(path)
+      assert_empty actual.requires
       assert_array %w[Module SuperKlass Module::Klass Rack Rack::Utm], actual.consts
+      assert_array %w[Module::Klass], actual.classes
+      assert_array %w[Module], actual.modules
     end
   end
 end

--- a/test/test_parse_ruby.rb
+++ b/test/test_parse_ruby.rb
@@ -219,11 +219,4 @@ class TestParseRuby < Minitest::Test
       assert_array %w[Module SuperKlass Module::Klass Rack Rack::Utm], actual.consts
     end
   end
-
-  class ErroringVisitor < Degem::Visitor
-    def visit_module_node(_node)
-      integer_node = Prism.parse("1").value.statements.body.first
-      super(integer_node)
-    end
-  end
 end

--- a/test/test_rubygem.rb
+++ b/test/test_rubygem.rb
@@ -130,4 +130,24 @@ class TestRubygem < Minitest::Test
       end
     end
   end
+
+  def test_it_detects_a_railtie
+    %w[::Rails::Railtie Rails::Railtie ::Rails::Engine Rails::Engine].each do |klass|
+      railtie = <<~CONTENT
+        module Foo
+          class Railtie < #{klass}
+          end
+        end
+      CONTENT
+
+      with_gemfile do
+        bundle_install(["foo" => railtie]) do |gemspec_paths|
+          rubygem = Bundler::Dependency.new("foo", nil)
+          gem_specification = TestableGemSpecification.new(gemspec_paths)
+          actual = Degem::Rubygem.new(rubygem:, gem_specification:)
+          assert_predicate actual, :railtie?
+        end
+      end
+    end
+  end
 end

--- a/test/test_rubygem.rb
+++ b/test/test_rubygem.rb
@@ -150,4 +150,19 @@ class TestRubygem < Minitest::Test
       end
     end
   end
+
+  def test_it_ignores_files_outside_of_lib
+    with_gemfile do
+      bundle_install(["foo" => "class Bar; end"]) do |gemspec_paths, gem_paths|
+        test_dir = File.join(gem_paths, "test")
+        FileUtils.mkdir_p(test_dir)
+        File.write(File.join(test_dir, "foo.rb"), "class Foo; end")
+        rubygem = Bundler::Dependency.new("foo", nil)
+        gem_specification = TestableGemSpecification.new(gemspec_paths)
+        actual = Degem::Rubygem.new(rubygem:, gem_specification:)
+        assert_array [], actual.own_consts
+        assert_array ["Bar"], actual.consts
+      end
+    end
+  end
 end

--- a/test/test_rubygem.rb
+++ b/test/test_rubygem.rb
@@ -149,7 +149,7 @@ class TestRubygem < Minitest::Test
         rubygem = Bundler::Dependency.new("foo", nil)
         gem_specification = TestableGemSpecification.new(gemspec_paths)
         actual = Degem::Rubygem.new(rubygem:, gem_specification:)
-        assert_array [], actual.own_consts
+        assert_array ["Bar"], actual.own_consts
       end
     end
   end

--- a/test/test_rubygem.rb
+++ b/test/test_rubygem.rb
@@ -10,7 +10,6 @@ class TestRubygem < Minitest::Test
         gem_specification = TestableGemSpecification.new(gemspec_paths)
         actual = Degem::Rubygem.new(rubygem:, gem_specification:)
         assert_array ["Foo"], actual.own_consts
-        assert_array ["Foo", "Foo::Bar"], actual.consts
       end
     end
   end
@@ -22,7 +21,6 @@ class TestRubygem < Minitest::Test
         gem_specification = TestableGemSpecification.new(gemspec_paths)
         actual = Degem::Rubygem.new(rubygem:, gem_specification:)
         assert_array ["FooBarBaz"], actual.own_consts
-        assert_array ["FooBarBaz"], actual.consts
       end
     end
   end
@@ -34,7 +32,6 @@ class TestRubygem < Minitest::Test
         gem_specification = TestableGemSpecification.new(gemspec_paths)
         actual = Degem::Rubygem.new(rubygem:, gem_specification:)
         assert_array ["Foo::Bar", "Foo::Bar::Baz"], actual.own_consts
-        assert_array ["Foo", "Foo::Bar", "Foo::Bar::Baz"], actual.consts
       end
     end
   end
@@ -46,7 +43,6 @@ class TestRubygem < Minitest::Test
         gem_specification = TestableGemSpecification.new(gemspec_paths)
         actual = Degem::Rubygem.new(rubygem:, gem_specification:)
         assert_array ["Foo::Bar"], actual.own_consts
-        assert_array ["Foo", "Foo::Bar"], actual.consts
       end
     end
 
@@ -56,7 +52,6 @@ class TestRubygem < Minitest::Test
         gem_specification = TestableGemSpecification.new(gemspec_paths)
         actual = Degem::Rubygem.new(rubygem:, gem_specification:)
         assert_array ["Bar::Baz"], actual.own_consts
-        assert_array ["Bar", "Bar::Baz"], actual.consts
       end
     end
   end
@@ -68,7 +63,6 @@ class TestRubygem < Minitest::Test
         gem_specification = TestableGemSpecification.new(gemspec_paths)
         actual = Degem::Rubygem.new(rubygem:, gem_specification:)
         assert_array ["FooBar"], actual.own_consts
-        assert_array ["FooBar"], actual.consts
       end
     end
   end
@@ -80,7 +74,6 @@ class TestRubygem < Minitest::Test
         gem_specification = TestableGemSpecification.new(gemspec_paths)
         actual = Degem::Rubygem.new(rubygem:, gem_specification:)
         assert_array ["FooBarBaz"], actual.own_consts
-        assert_array ["FooBarBaz"], actual.consts
       end
     end
   end
@@ -92,7 +85,6 @@ class TestRubygem < Minitest::Test
         gem_specification = TestableGemSpecification.new(gemspec_paths)
         actual = Degem::Rubygem.new(rubygem:, gem_specification:)
         assert_array ["Foo::Bar", "Foo::Bar::Baz"], actual.own_consts
-        assert_array ["Foo", "Foo::Bar", "Foo::Bar::Baz"], actual.consts
       end
     end
   end
@@ -104,7 +96,6 @@ class TestRubygem < Minitest::Test
         gem_specification = TestableGemSpecification.new(gemspec_paths)
         actual = Degem::Rubygem.new(rubygem:, gem_specification:)
         assert_array ["Foo::Bar"], actual.own_consts
-        assert_array ["Foo", "Foo::Bar"], actual.consts
       end
     end
 
@@ -114,7 +105,6 @@ class TestRubygem < Minitest::Test
         gem_specification = TestableGemSpecification.new(gemspec_paths)
         actual = Degem::Rubygem.new(rubygem:, gem_specification:)
         assert_array ["Bar::Baz"], actual.own_consts
-        assert_array ["Bar", "Bar::Baz"], actual.consts
       end
     end
   end
@@ -126,7 +116,6 @@ class TestRubygem < Minitest::Test
         gem_specification = TestableGemSpecification.new(gemspec_paths)
         actual = Degem::Rubygem.new(rubygem:, gem_specification:)
         assert_array ["FooBar"], actual.own_consts
-        assert_array ["FooBar"], actual.consts
       end
     end
   end
@@ -161,7 +150,6 @@ class TestRubygem < Minitest::Test
         gem_specification = TestableGemSpecification.new(gemspec_paths)
         actual = Degem::Rubygem.new(rubygem:, gem_specification:)
         assert_array [], actual.own_consts
-        assert_array ["Bar"], actual.consts
       end
     end
   end

--- a/test/test_rubygem.rb
+++ b/test/test_rubygem.rb
@@ -9,7 +9,7 @@ class TestRubygem < Minitest::Test
         rubygem = Bundler::Dependency.new("foo", nil)
         gem_specification = TestableGemSpecification.new(gemspec_paths)
         actual = Degem::Rubygem.new(rubygem:, gem_specification:)
-        assert_array ["Foo"], actual.own_consts
+        assert_array ["Foo", "Foo::Bar"], actual.own_consts
       end
     end
   end


### PR DESCRIPTION
This PR improves the own classes detection. 

For example, it is now able to detect the usage of the following gems:
- [sendgrid-ruby](http://github.com/sendgrid/sendgrid-ruby)
- [hubspot-api-client](https://github.com/HubSpot/hubspot-api-ruby)
- [countries](countries)
- [ruby-saml](https://github.com/saml-toolkits/ruby-saml)

which was not possible before because they expose classes that are not easily computed from the gem name (eg, `hubspot-api-client` -> `Hubspot::Client`).

Though, it introduces a regression like in the case of `webrick` that introduces [`Errno`](https://github.com/ruby/webrick/blob/307f24c0e9624e56fdbe8ebbe6df03ee25e9e57b/lib/webrick/compat.rb#L3) for compatibility, which could be rescued in an app that is using a different server.